### PR TITLE
fix(file-validation): Change dynamic material check to store data in Map instead of Set

### DIFF
--- a/Scripts/Internal/FileValidation/archiveXL.wscript
+++ b/Scripts/Internal/FileValidation/archiveXL.wscript
@@ -88,7 +88,7 @@ export function resolveSubstitution(paths) {
         }
 
         if (currentMaterialName && path.includes('{material}')) {
-            (dynamicMaterials[currentMaterialName] || []).forEach((materialName) => {
+            (dynamicMaterials.get(currentMaterialName) || []).forEach((materialName) => {
                 ret.push(path.replace('{material}', materialName));
             });
             return ret;

--- a/Scripts/Wolvenkit_FileValidation.wscript
+++ b/Scripts/Wolvenkit_FileValidation.wscript
@@ -887,7 +887,7 @@ export function SetNumAppearances(number) {
     numAppearances = number;
 }
 
-export let dynamicMaterials = new Set();
+export let dynamicMaterials = new Map();
 export var currentMaterialName = "";
 
 export function SetCurrentMaterialName(newValue) {


### PR DESCRIPTION
The previous implementation used Set for the dynamicMaterials field, but used the indexer for access. This did not call Set functions, but Object functions, so the dynamicMaterials.clear() call did not actually clear the stored data. This led to a false positive error when checking mesh ents where the first mesh component used dynamic materials, but the second (e.g. a shadow mesh) did not. Since the dynamicMaterials field still stored the dynamic materials name of the previous component it would show an error. Changed the implementation to use Map and its has/get/set functions.

PS: For some perverse reason this error did not occur for every .ent that had one dynamic and one non-dynamic mesh component. I have zero clue why that is.