### PR TITLE
FileValidation: add questphase prefab NodeRef check

### DIFF
--- a/Scripts/Internal/FileValidation/graph_questphase.wscript
+++ b/Scripts/Internal/FileValidation/graph_questphase.wscript
@@ -5,6 +5,39 @@ import { checkIfFileIsBroken } from "00_shared.wscript";
 import { getPathToCurrentFile  } from '../../Wolvenkit_FileValidation.wscript';
 import * as Logger from '../../Logger.wscript';
 
+function getData(value) {
+    return value?.Data ?? value;
+}
+
+function getNodeRefValue(nodeRef) {
+    return nodeRef?.$value ?? nodeRef?.value ?? nodeRef?.Value ?? nodeRef;
+}
+
+function getNodeRefStorage(nodeRef) {
+    return nodeRef?.$storage ?? nodeRef?.storage ?? nodeRef?.Storage ?? typeof nodeRef;
+}
+
+function isZeroNumericNodeRef(nodeRef) {
+    const value = getNodeRefValue(nodeRef);
+    return value !== undefined && value !== null && `${value}` === '0';
+}
+
+function validatePhasePrefabs(phasePrefabs) {
+    if (!phasePrefabs || phasePrefabs.length === undefined) return;
+
+    for (let i = 0; i < phasePrefabs.length; i++) {
+        const phasePrefab = getData(phasePrefabs[i]);
+        const prefabNodeRef = phasePrefab?.prefabNodeRef;
+        if (!isZeroNumericNodeRef(prefabNodeRef)) continue;
+
+        Logger.Error(
+            `phasePrefabs[${i}].prefabNodeRef is NodeRef ${getNodeRefStorage(prefabNodeRef)} 0. `
+            + `A phasePrefabs entry has a prefabNodeRef, but it is set to NodeRef 0 instead of a valid node path. `
+            + `This will prevent the questphase from loading. Use a valid NodeRef, or delete the phasePrefabs entry if this phase has no prefab dependency. File ${getPathToCurrentFile()}`
+        );
+    }
+}
+
 /**
  * 
  * @param {{ Data: { RootChunk } }} questphase
@@ -17,6 +50,8 @@ export function validateQuestphaseFile(questphase, _questphaseSettings) {
 
     if (questphase?.Data?.RootChunk) return validateQuestphaseFile(questphase.Data.RootChunk, _questphaseSettings);
     if (checkIfFileIsBroken(questphase, 'questphase')) return;
+
+    validatePhasePrefabs(questphase.phasePrefabs);
 
     const nodeIDs = [];
 


### PR DESCRIPTION
a massive pain in the ass footgun hiding in plain sight, I ended up REing the questphase loader to finally realize what I was doing wrong. This should save the next poor soul many hours

Basically: if you create a prefabNodeRef entry but forget to populate the noderef entry, it's left at 0 and when the game loads the questphase and tries to load the prefab - it tries to load the 0 noderef (it doesnt check it's 0) and just never ends up loading the questphase at all