### PR TITLE
add default templates for sectors and quest phase resources

### DIFF
--- a/Templates/default.questQuestPhaseResource.json
+++ b/Templates/default.questQuestPhaseResource.json
@@ -1,0 +1,19 @@
+{
+  "FormatVersion": 1,
+  "Author": "sprt_",
+  "Description": "Empty quest phase resource with graph changed to work out of the box.",
+  "Version": "1",
+  "Data": {
+    "$type": "questQuestPhaseResource",
+    "cookingPlatform": "PLATFORM_None",
+    "graph": {
+      "HandleId": "0",
+      "Data": {
+        "$type": "questGraphDefinition",
+        "nodes": []
+      }
+    },
+    "inplacePhases": [],
+    "phasePrefabs": []
+  }
+}

--- a/Templates/default.worldStreamingSector.json
+++ b/Templates/default.worldStreamingSector.json
@@ -1,0 +1,35 @@
+{
+  "FormatVersion": 1,
+  "Author": "sprt_",
+  "Description": "Empty sector with version and variantIndices changed to work out of the box.",
+  "Version": "1",
+  "Data": {
+    "$type": "worldStreamingSector",
+    "category": "Unknown",
+    "cookingPlatform": "PLATFORM_None",
+    "externInplaceResource": {
+      "DepotPath": {
+        "$type": "ResourcePath",
+        "$storage": "uint64",
+        "$value": "0"
+      },
+      "Flags": "Soft"
+    },
+    "level": 255,
+    "localInplaceResource": [],
+    "nodeData": {
+      "BufferId": "0",
+      "Flags": 0,
+      "Bytes": ""
+    },
+    "nodeRefs": [],
+    "nodes": [],
+    "persistentNodeIndex": 0,
+    "persistentNodes": null,
+    "variantIndices": [
+      0
+    ],
+    "variantNodes": null,
+    "version": 62
+  }
+}


### PR DESCRIPTION
# add default templates for sectors and quest phase resources

resolves [#2754: insensible default value for variantIndicies in new worldstreamingsectors](<https://github.com/WolvenKit/WolvenKit/issues/2754>) and [#2016: Wrong version of .streamingsector file created by editor](<https://github.com/WolvenKit/WolvenKit/issues/2016>)
is part of fixing [#2933: Issue while saving new questphase files](<https://github.com/WolvenKit/WolvenKit/issues/2933>) 